### PR TITLE
Bootstrap Astro scaffold

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['astro'],
+  extends: ['eslint:recommended', 'plugin:astro/recommended'],
+  env: {
+    es2022: true,
+    node: true,
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "skip" ]; then
+    debug "HUSKY env variable is set to skip hooks"
+    exit 0
+  fi
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint && pnpm format

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# agentmddev-website
+# AgentMD.dev Website
+
+This is a scaffold for the AgentMD.dev website built with [Astro](https://astro.build/) and Tailwind CSS.
+
+## Development
+
+```bash
+pnpm install
+pnpm dev
+```
+
+## Build
+
+```bash
+pnpm build
+```

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+  site: 'https://agentmd.dev',
+  integrations: [mdx(), sitemap()],
+  markdown: {
+    shikiConfig: {
+      theme: 'github-dark',
+    },
+  },
+});

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  '*.{js,jsx,ts,tsx,astro,mdx,md}': ['prettier --write'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "agentmd-dev",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "format": "prettier --write .",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.astro",
+    "postinstall": ""
+  },
+  "dependencies": {
+    "astro": "^3.5.0",
+    "@astrojs/mdx": "^3.0.0",
+    "@astrojs/sitemap": "^3.0.0",
+    "astro-code": "^0.1.0",
+    "pagefind": "^1.0.0",
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "@types/node": "^20.0.0",
+    "eslint": "^8.0.0",
+    "eslint-plugin-astro": "^0.25.0",
+    "prettier": "^2.8.0",
+    "prettier-plugin-tailwindcss": "^0.2.1",
+    "husky": "^8.0.0",
+    "lint-staged": "^13.0.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,0 +1,18 @@
+<nav class="sticky top-0 z-50 bg-white/80 backdrop-blur dark:bg-agent-dark/80">
+  <div class="mx-auto flex max-w-6xl items-center justify-between p-4">
+    <a href="/" class="text-lg font-bold">AgentMD.dev</a>
+    <div class="flex items-center gap-4">
+      <a href="/">Home</a>
+      <a href="/agents/">All Agents</a>
+      <a href="/blog/">Blog</a>
+      <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a>
+      <button id="theme-toggle" class="ml-4">🌓</button>
+    </div>
+  </div>
+</nav>
+<script>
+  const btn = document.getElementById('theme-toggle');
+  btn.addEventListener('click', () => {
+    document.documentElement.classList.toggle('dark');
+  });
+</script>

--- a/src/content/agents/hello/index.mdx
+++ b/src/content/agents/hello/index.mdx
@@ -1,0 +1,6 @@
+---
+title: Hello Agent
+brief: Example agent template.
+---
+
+This is a sample agent.md.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,11 @@
+import { defineCollection, z } from 'astro:content';
+
+const agents = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    brief: z.string(),
+  }),
+});
+
+export const collections = { agents };

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,0 +1,28 @@
+---
+const { title = 'AgentMD.dev', description, url } = Astro.props;
+---
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#00bcd4" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+    <meta property="og:site_name" content="AgentMD.dev" />
+    {title && <meta property="og:title" content={title} />}
+    {description && <meta property="og:description" content={description} />}
+    {url && <meta property="og:url" content={url} />}
+    {title && <meta name="twitter:title" content={title} />}
+    {description && <meta name="twitter:description" content={description} />}
+    <script type="application/ld+json">{
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "AgentMD.dev",
+      "url": "https://agentmd.dev"
+    }</script>
+  </head>
+  <body class="min-h-screen bg-white text-gray-900 dark:bg-agent-dark dark:text-white">
+    <slot />
+  </body>
+</html>

--- a/src/pages/agents/index.astro
+++ b/src/pages/agents/index.astro
@@ -1,0 +1,19 @@
+---
+import Base from '../../layouts/Base.astro';
+import Nav from '../../components/Nav.astro';
+const agents = await Astro.glob('../../content/agents/*/index.mdx');
+---
+<Base title="All Agents | AgentMD.dev">
+  <Nav />
+  <main class="mx-auto max-w-6xl p-4">
+    <h1 class="mb-4 text-3xl font-bold">All Agents</h1>
+    <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      {agents.map(agent => (
+        <a href={agent.url} class="rounded border p-4" key={agent.url}>
+          <h2 class="font-semibold">{agent.frontmatter.title}</h2>
+          <p>{agent.frontmatter.brief}</p>
+        </a>
+      ))}
+    </div>
+  </main>
+</Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,34 @@
+---
+import Base from '../layouts/Base.astro';
+import Nav from '../components/Nav.astro';
+const agents = await Astro.glob('../content/agents/*/index.mdx');
+const count = agents.length;
+---
+<Base title="agent.md Examples for AutoGPT, CrewAI & More | AgentMD.dev" description="Download ready-to-copy agent.md templates and examples." url="https://agentmd.dev/">
+  <Nav />
+  <main class="mx-auto max-w-6xl p-4">
+    <section class="py-20 text-center">
+      <h1 class="text-4xl font-bold mb-4">Ready-to-copy agent.md templates</h1>
+      <p class="mb-6 text-lg">Browse examples optimized for AutoGPT, CrewAI and more.</p>
+      <a href="/agents/" class="rounded bg-agent-primary px-6 py-3 text-white">Browse Agents</a>
+      <div id="search" class="mt-8"></div>
+    </section>
+    <section class="grid gap-4 sm:grid-cols-2 md:grid-cols-3" aria-label="Agent list">
+      {agents.sort((a,b)=>a.frontmatter.title.localeCompare(b.frontmatter.title)).map(agent => (
+        <div class="rounded border p-4" key={agent.url}>
+          <h2 class="text-xl font-semibold">{agent.frontmatter.title}</h2>
+          <p class="mb-2">{agent.frontmatter.brief}</p>
+          <a href={agent.url} class="text-agent-primary">View example</a>
+        </div>
+      ))}
+    </section>
+    <section class="mt-8 text-center" aria-label="Site stats">
+      ✅ {count} agent.md files • Last update {/*
+      */}{new Date().toISOString().substring(0,10)}
+    </section>
+  </main>
+</Base>
+<script type="module" is:inline>
+  import Pagefind from 'pagefind';
+  Pagefind.mount({ element: '#search' });
+</script>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./src/**/*.{astro,md,mdx}'],
+  theme: {
+    extend: {
+      colors: {
+        'agent-primary': '#00bcd4',
+        'agent-dark': '#0f172a',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "astro/tsconfigs/base",
+  "compilerOptions": {
+    "strict": true,
+    "types": ["node"],
+    "jsx": "preserve"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Astro project skeleton with Tailwind
- set up MDX, sitemap and shiki support
- add basic layout, navigation and home page with card loop
- configure Prettier, ESLint, Husky and CI workflow
- include pagefind search island

## Testing
- `pnpm lint` *(fails: ESLint config not found)*
- `pnpm build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6245e9f0832c8511b26ce0c2fc17